### PR TITLE
fix(signup-endpoint) remove option for user to choose what they are o…

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -15,12 +15,12 @@ class userController {
   // ================================================== SIGNUP =====================================
   static signup(req, res) {
     const {
-      firstName, lastName, email, password, type, isAdmin,
+      firstName, lastName, email, password, type,
     } = req.body;
 
     const idNo = userModal.length + 1;
     const jwtoken = jwt.sign({ id: idNo }, process.env.NEVERMIND);
-
+    const isAdmin = false;
     const newUser = schema.validate({
       id: idNo, firstName, lastName, email, password, type, isAdmin,
     });


### PR DESCRIPTION
#### What does this PR do?
- Will remove the option for a user to choose what they are on the system
#### Description of Task to be completed?
- users should not have the ability to choose the type of user they are on the system when signing up
#### How should this be manually tested?
- use [postman](https://www.getpostman.com/downloads/) to test the following endpoint as a POST method
```
https://cha-ii.herokuapp.com/api/v1/auth/signup
```
- Then provide (First name, Last name, email, password, type) as shown in the screenshot

#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
[#165376530](https://www.pivotaltracker.com/story/show/165376530)
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/30442301/56198922-236a8b00-603c-11e9-9e81-85a13271d39a.png)

#### Questions:
- N/A