### PR TITLE
fix(create-account-endpoint) remove the option to add opening balance…

### DIFF
--- a/src/controllers/accountController.js
+++ b/src/controllers/accountController.js
@@ -8,9 +8,10 @@ import search from '../helpers/search';
 class accountController {
   // ======================================== BANK ACCOUNTS ====================================
   static createAccount(req, res) {
-    const { type, balance } = req.body;
+    const { type } = req.body;
     const { id } = req.user;
     const accountOwner = userModal.find(usr => usr.id === id);
+    const balance = 0;
     const newAccount = schema.validate({
       id: bankAccount.length + 1,
       accountNumber: bankAccount.length + 1,
@@ -21,7 +22,7 @@ class accountController {
       balance,
     });
     if (!newAccount.error) {
-      bankAccount.push(newAccount);
+      bankAccount.push(newAccount.value);
       return res.status(201).json({
         status: 201,
         data: {

--- a/src/controllers/validation/bankAccountSchema.js
+++ b/src/controllers/validation/bankAccountSchema.js
@@ -7,6 +7,6 @@ const bankAccounntSchema = joi.object().keys({
   owner: joi.number().positive().required(),
   type: joi.string().min(4).required(),
   status: joi.string().min(4).required(),
-  balance: joi.number().positive().required(),
+  balance: joi.number().required(),
 });
 export default bankAccounntSchema;

--- a/src/controllers/validation/transactionSchema.js
+++ b/src/controllers/validation/transactionSchema.js
@@ -7,7 +7,7 @@ const transactionSchema = joi.object().keys({
   accountNumber: joi.number().positive().required(),
   cashier: joi.number().positive().required(),
   amount: joi.number().positive().required(),
-  oldBalance: joi.number().positive().required(),
-  newBalance: joi.number().positive().required(),
+  oldBalance: joi.number().required(),
+  newBalance: joi.number().required(),
 });
 export default transactionSchema;

--- a/src/tests/accountTests.js
+++ b/src/tests/accountTests.js
@@ -46,7 +46,7 @@ describe('Bank account tests', () => {
   });
   it('should not be able to create new bank account without required information', (done) => {
     const newAccount = {
-      type: 'savings',
+      type: '',
     };
     chai.request(server)
       .post('/api/v1/accounts')

--- a/src/tests/userTests.js
+++ b/src/tests/userTests.js
@@ -15,8 +15,8 @@ describe('User tests', () => {
       lastName: 'Shema',
       email: 'james@gmail.com',
       password: '12345678',
+      retype: '12345678',
       type: 'client',
-      isAdmin: 'false',
     };
     chai.request(server)
       .post('/api/v1/auth/signup')


### PR DESCRIPTION
#### What does this PR do?
- Will remove the option to add opening balance when creating a user account
- Will also update test
#### Description of Task to be completed?
- user should not have the ability to choose their opening balance when creating a bank account
- update unit tests to reflect changes made.
#### How should this be manually tested?
- use [postman](https://www.getpostman.com/downloads/) to test the following endpoint as a PATCH method
```
https://cha-ii.herokuapp.com/api/v1/account/:id
```
- Then provide the type of account you want to create(Savings, Current)  as shown in the screenshot

#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
[#165377034](https://www.pivotaltracker.com/story/show/165377034)
[#165381469](https://www.pivotaltracker.com/story/show/165381469)
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/30442301/56212684-cc27e300-605a-11e9-88d3-f82c5dec99fd.png)

#### Questions:
- N/A