### PR TITLE
validate account status and type when a user creates a bank account or when admin change 

### DIFF
--- a/src/controllers/accountController.js
+++ b/src/controllers/accountController.js
@@ -4,6 +4,7 @@ import bankAccount from '../modals/bankAccounts';
 import userModal from '../modals/user';
 import schema from './validation/bankAccountSchema';
 import search from '../helpers/search';
+import schemaStatus from './validation/accountStatusSchema';
 
 class accountController {
   // ======================================== BANK ACCOUNTS ====================================
@@ -41,6 +42,10 @@ class accountController {
   // ================================== CHANGE ACCOUNT STATUS ==============================
   static changeAccountStatus(req, res) {
     const { status } = req.body;
+    const checkStatus = schemaStatus.validate(req.body);
+    if (checkStatus.error) {
+      return res.status(400).json({ status: 400, error: 'account can only be change to dormant, draft, or active' });
+    }
     const searchUser = search.searchUser(req.user.id);
     if (searchUser.isAdmin === true) {
       const searchBankAccount = bankAccount.find(account => account.accountNumber === parseInt(req.params.id, 10));

--- a/src/controllers/accountController.js
+++ b/src/controllers/accountController.js
@@ -4,13 +4,15 @@ import bankAccount from '../modals/bankAccounts';
 import userModal from '../modals/user';
 import schema from './validation/bankAccountSchema';
 import search from '../helpers/search';
+import schemaStatus from './validation/accountStatusSchema';
 
 class accountController {
   // ======================================== BANK ACCOUNTS ====================================
   static createAccount(req, res) {
-    const { type, balance } = req.body;
+    const { type } = req.body;
     const { id } = req.user;
     const accountOwner = userModal.find(usr => usr.id === id);
+    const balance = 0;
     const newAccount = schema.validate({
       id: bankAccount.length + 1,
       accountNumber: bankAccount.length + 1,
@@ -21,7 +23,7 @@ class accountController {
       balance,
     });
     if (!newAccount.error) {
-      bankAccount.push(newAccount);
+      bankAccount.push(newAccount.value);
       return res.status(201).json({
         status: 201,
         data: {
@@ -40,6 +42,10 @@ class accountController {
   // ================================== CHANGE ACCOUNT STATUS ==============================
   static changeAccountStatus(req, res) {
     const { status } = req.body;
+    const checkStatus = schemaStatus.validate(req.body);
+    if (checkStatus.error) {
+      return res.status(400).json({ status: 400, error: 'account can only be change to dormant, draft, or active' });
+    }
     const searchUser = search.searchUser(req.user.id);
     if (searchUser.isAdmin === true) {
       const searchBankAccount = bankAccount.find(account => account.accountNumber === parseInt(req.params.id, 10));

--- a/src/controllers/validation/accountStatusSchema.js
+++ b/src/controllers/validation/accountStatusSchema.js
@@ -1,0 +1,6 @@
+import joi from 'joi';
+
+const checkStatus = joi.object().keys({
+  status: joi.string().valid('dormant', 'active', 'draft').required(),
+});
+export default checkStatus;

--- a/src/controllers/validation/bankAccountSchema.js
+++ b/src/controllers/validation/bankAccountSchema.js
@@ -5,8 +5,8 @@ const bankAccounntSchema = joi.object().keys({
   accountNumber: joi.number().positive().required(),
   createdOn: joi.date().required(),
   owner: joi.number().positive().required(),
-  type: joi.string().min(4).required(),
-  status: joi.string().min(4).required(),
+  type: joi.string().valid('current', 'savings').required(),
+  status: joi.string().valid('dormant', 'active', 'draft').required(),
   balance: joi.number().required(),
 });
 export default bankAccounntSchema;

--- a/src/controllers/validation/bankAccountSchema.js
+++ b/src/controllers/validation/bankAccountSchema.js
@@ -5,8 +5,8 @@ const bankAccounntSchema = joi.object().keys({
   accountNumber: joi.number().positive().required(),
   createdOn: joi.date().required(),
   owner: joi.number().positive().required(),
-  type: joi.string().min(4).required(),
-  status: joi.string().min(4).required(),
-  balance: joi.number().positive().required(),
+  type: joi.string().valid('current', 'savings').required(),
+  status: joi.string().valid('dormant', 'active', 'draft').required(),
+  balance: joi.number().required(),
 });
 export default bankAccounntSchema;

--- a/src/controllers/validation/transactionSchema.js
+++ b/src/controllers/validation/transactionSchema.js
@@ -7,7 +7,7 @@ const transactionSchema = joi.object().keys({
   accountNumber: joi.number().positive().required(),
   cashier: joi.number().positive().required(),
   amount: joi.number().positive().required(),
-  oldBalance: joi.number().positive().required(),
-  newBalance: joi.number().positive().required(),
+  oldBalance: joi.number().required(),
+  newBalance: joi.number().required(),
 });
 export default transactionSchema;

--- a/src/tests/accountTests.js
+++ b/src/tests/accountTests.js
@@ -46,7 +46,7 @@ describe('Bank account tests', () => {
   });
   it('should not be able to create new bank account without required information', (done) => {
     const newAccount = {
-      type: 'savings',
+      type: '',
     };
     chai.request(server)
       .post('/api/v1/accounts')

--- a/src/tests/userTests.js
+++ b/src/tests/userTests.js
@@ -15,8 +15,8 @@ describe('User tests', () => {
       lastName: 'Shema',
       email: 'james@gmail.com',
       password: '12345678',
+      retype: '12345678',
       type: 'client',
-      isAdmin: 'false',
     };
     chai.request(server)
       .post('/api/v1/auth/signup')


### PR DESCRIPTION
#### What does this PR do?
- will validate account status and type when a user creates a bank account or when admin change account status
#### Description of Task to be completed?
- validate user's input when  changing account type and status
#### How should this be manually tested?
- use [postman](https://www.getpostman.com/downloads/) to test the following endpointS as a POST, PATCH method respectively
```
https://cha-ii.herokuapp.com/api/v1/accounts/
https://cha-ii.herokuapp.com/api/v1/account/:id
```
- Then provide the type of account you want to create(savings, current)  as shown in the screenshot or
- Provide the status of the account as you want to change it(As admin)

#### Any background context you want to provide?
- N/A
#### What are the relevant pivotal tracker stories?
[#165382457](https://www.pivotaltracker.com/story/show/165382457)
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/30442301/56218460-507f6380-6065-11e9-8e52-4993d5c507f0.png)
![image](https://user-images.githubusercontent.com/30442301/56218548-760c6d00-6065-11e9-86ce-38da9dec6b02.png)


#### Questions:
- N/A